### PR TITLE
Fix for multiple option

### DIFF
--- a/Resources/views/Form/typeahead.html.twig
+++ b/Resources/views/Form/typeahead.html.twig
@@ -56,7 +56,11 @@
 
 {% block entity_typeahead_list_widget %}
 {% spaceless %}
-    {% set _id, _value, _render = child, child, child %}
+    {% if simple or child == null %}
+        {% set _id, _value, _render = child, child, child %}
+    {% else %}
+        {% set _id, _value, _render = child.id, attribute(child, property ?: 'id'), attribute(child, render) %}
+    {% endif %}
     <li{% if child is not null %} data-value="{{ _id }}"{% endif %}>
         <input{% if child is not null %} id="{{ id ~ '_' ~ _id }}" name="{{ full_name }}[]" value="{{ _value }}"{% endif %} type="hidden" />
         <a href="" class="lifo-typeahead-item" title="{{ "Click to remove"|trans }}">{{ child is not null ? _render : '' }}</a>

--- a/Resources/views/Form/typeahead.html.twig
+++ b/Resources/views/Form/typeahead.html.twig
@@ -56,11 +56,7 @@
 
 {% block entity_typeahead_list_widget %}
 {% spaceless %}
-    {% if simple %}
-        {% set _id, _value, _render = child, child, child %}
-    {% else %}
-        {% set _id, _value, _render = child.id, attribute(child, property ?: 'id'), attribute(child, render) %}
-    {% endif %}
+    {% set _id, _value, _render = child, child, child %}
     <li{% if child is not null %} data-value="{{ _id }}"{% endif %}>
         <input{% if child is not null %} id="{{ id ~ '_' ~ _id }}" name="{{ full_name }}[]" value="{{ _value }}"{% endif %} type="hidden" />
         <a href="" class="lifo-typeahead-item" title="{{ "Click to remove"|trans }}">{{ child is not null ? _render : '' }}</a>


### PR DESCRIPTION
When multiple child is set to null (line 30) and on line 62 is called child.id
That comprobation throws an error. I don't fully understand why it calls for child.id because after I quit this if() the field started working and it does everything that it should do (adds the <ul>, saves on the DB, list the existing ones if the Entity have them, etc.)
PS: Sorry about my bad english I'm a spanish speaker